### PR TITLE
zl2te_arduino changes to IcomAH4 tuner pinout

### DIFF
--- a/zl2te_arduino/README.md
+++ b/zl2te_arduino/README.md
@@ -35,7 +35,8 @@ Using the header pin jumpers:
 * jumper from J4 pin 6 to J7 pin 6.
 * Solder a wire from +5V on the Pico board to J7 pin 9. (Not used in this case but done to provide 5 volts to peripherals in future experiments)
 
-####:warning: Note:
+:warning: Note:
+
 I have used J4 pin 6 for filter switching. This had been previously assigned to the IcomAh4 START line so to avoid a clash the IcomAh4 START line has now been assigned to GPIO09_Out7.
 
 ## Converting the files:

--- a/zl2te_arduino/README.md
+++ b/zl2te_arduino/README.md
@@ -37,7 +37,7 @@ Using the header pin jumpers:
 
 :warning: Note:
 
-I have used J4 pin 6 for filter switching. This had been previously assigned to the IcomAh4 START line so to avoid a clash the IcomAh4 START line has now been assigned to GPIO09_Out7.
+I have used J4 pin 6 for filter switching. This had been previously assigned to the IcomAh4 START line. To avoid a clash, the IcomAh4 START line has now been assigned to GPIO09_Out7.
 
 ## Converting the files:
 

--- a/zl2te_arduino/README.md
+++ b/zl2te_arduino/README.md
@@ -35,7 +35,7 @@ Using the header pin jumpers:
 * jumper from J4 pin 6 to J7 pin 6.
 * Solder a wire from +5V on the Pico board to J7 pin 9. (Not used in this case but done to provide 5 volts to peripherals in future experiments)
 
-<span style="color:red">some *red* Note</span> that I have used J4 pin 6 for filter switching. This had been previously assigned to the IcomAh4 START line so to avoid a clash the IcomAh4 START line has now been assigned to GPIO09_Out7.
+:warning:Note that I have used J4 pin 6 for filter switching. This had been previously assigned to the IcomAh4 START line so to avoid a clash the IcomAh4 START line has now been assigned to GPIO09_Out7.
 
 ## Converting the files:
 

--- a/zl2te_arduino/README.md
+++ b/zl2te_arduino/README.md
@@ -35,7 +35,7 @@ Using the header pin jumpers:
 * jumper from J4 pin 6 to J7 pin 6.
 * Solder a wire from +5V on the Pico board to J7 pin 9. (Not used in this case but done to provide 5 volts to peripherals in future experiments)
 
-
+<span style="color:red">some *red* Note</span> that I have used J4 pin 6 for filter switching. This had been previously assigned to the IcomAh4 START line so to avoid a clash the IcomAh4 START line has now been assigned to GPIO09_Out7.
 
 ## Converting the files:
 

--- a/zl2te_arduino/README.md
+++ b/zl2te_arduino/README.md
@@ -35,7 +35,8 @@ Using the header pin jumpers:
 * jumper from J4 pin 6 to J7 pin 6.
 * Solder a wire from +5V on the Pico board to J7 pin 9. (Not used in this case but done to provide 5 volts to peripherals in future experiments)
 
-:warning:Note that I have used J4 pin 6 for filter switching. This had been previously assigned to the IcomAh4 START line so to avoid a clash the IcomAh4 START line has now been assigned to GPIO09_Out7.
+####:warning: Note:
+I have used J4 pin 6 for filter switching. This had been previously assigned to the IcomAh4 START line so to avoid a clash the IcomAh4 START line has now been assigned to GPIO09_Out7.
 
 ## Converting the files:
 

--- a/zl2te_arduino/zl2te_arduino.ino
+++ b/zl2te_arduino/zl2te_arduino.ino
@@ -47,8 +47,8 @@ void loop() {               // Wait for something to happen
   }
 #endif
   // Control the Icom AH-4 antenna tuner.
-  // Assume the START line is on J4 pin 6 and the KEY line is on J8 pin 2.
-  IcomAh4(GPIO22_Out6, GPIO18_In2);
+  // Assume the START line is on J4 pin 7 and the KEY line is on J8 pin 2.
+  IcomAh4(GPIO22_Out7, GPIO18_In2);
   // Poll for a changed Tx band, Rx band and T/R change
   change_band = false;
   is_rx = gpio_get(GPIO13_EXTTR);  // true for receive, false for transmit


### PR DESCRIPTION
I clashed by assigning GPIO22_Out6 to filter switching. This was already used for the Icom AH-4 START line. It has been corrected by now assigning GPIO09_Out7 to the Icom AH-4 START line and a note to this effect has been added to the README.md